### PR TITLE
setup a separate build for 64 bit linux: x86_64-pc-linux-gnu, so host…

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -13,6 +13,20 @@ MRuby::Build.new do |conf|
   end
 
   conf.enable_bintest
+  conf.enable_debug
+
+  gem_config(conf)
+end
+
+MRuby::CrossBuild.new('x86_64-pc-linux-gnu') do |conf|
+  toolchain :gcc
+
+  [conf.cc, conf.cxx, conf.linker].each do |cc|
+    cc.flags << "-Wl,--no-as-needed"
+    cc.flags << "-ldl"
+  end
+
+  conf.build_mrbtest_lib_only
 
   gem_config(conf)
 end

--- a/release.sh
+++ b/release.sh
@@ -17,7 +17,7 @@ zip mjruby_linux_bin.zip mjruby
 mv *.zip ../../../../releases
 cd ../..
 
-cd host/bin
+cd x86_64-pc-linux-gnu/bin
 zip mjruby_linux_x86_64_bin.zip mjruby
 mv *.zip ../../../../releases
 cd ../..


### PR DESCRIPTION
… can have debug mode for being run in tests. Debug mode in mruby provides stack traces, which should make debugging errors much easier. :)
